### PR TITLE
Add unit tests for ellipsize and friendly_label

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -496,3 +496,33 @@ fn friendly_label(uri: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ellipsize_shorter_than_limit() {
+        let input = "a".repeat(TOOLTIP_MAX_CHARS - 1);
+        assert_eq!(ellipsize(&input, TOOLTIP_MAX_CHARS), input);
+    }
+
+    #[test]
+    fn ellipsize_equal_to_limit() {
+        let input = "a".repeat(TOOLTIP_MAX_CHARS);
+        assert_eq!(ellipsize(&input, TOOLTIP_MAX_CHARS), input);
+    }
+
+    #[test]
+    fn ellipsize_longer_than_limit() {
+        let input = "a".repeat(TOOLTIP_MAX_CHARS + 5);
+        let expected = format!("{}…", "a".repeat(TOOLTIP_MAX_CHARS));
+        assert_eq!(ellipsize(&input, TOOLTIP_MAX_CHARS), expected);
+    }
+
+    #[test]
+    fn friendly_label_basic() {
+        let uri = "https://example.com/FooBarBaz";
+        assert_eq!(friendly_label(uri), "Foo Bar Baz");
+    }
+}


### PR DESCRIPTION
## Summary
- add new unit tests covering `ellipsize` for shorter, equal, and longer inputs
- test `friendly_label` output on a camel-case URI

## Testing
- `cargo test --locked`

------
https://chatgpt.com/codex/tasks/task_e_683f80f41004832b95bd4b37974d0cd2