### PR TITLE
Move vibe coding badge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Contribution Guidelines
+
+- Before committing, run `cargo test` to ensure tests pass.
+  - If tests fail due to missing dependencies, note it in the pull request.
+- Keep commit messages concise and in imperative mood (e.g. "add feature" rather than "added feature").
+
+![🌈 Powered by ✨ vibe coding ✨](https://img.shields.io/badge/🌈%20Powered%20by-✨%20vibe%20coding%20✨-ff69b4?style=for-the-badge)
+


### PR DESCRIPTION
## Summary
- relocate the badge in `AGENTS.md` to appear after the guideline text

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_683f8f80a174832baa4e43d096da1324