### PR TITLE
Document XSD_DATETYPE usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
   - If tests fail due to missing dependencies, note it in the pull request.
 - Keep commit messages concise and in imperative mood (e.g. "add feature" rather than "added feature").
 - Base the pull request title and description on the changes in the pull request as a whole.
+- The constant `XSD_DATETYPE` in `src/main.rs` correctly references Tracker's URI `http://www.w3.org/2001/XMLSchema#dateType`.
+  Renaming the constant or altering this URI would be incorrect.
 
 ![🌈 Powered by ✨ vibe coding ✨](https://img.shields.io/badge/🌈%20Powered%20by-✨%20vibe%20coding%20✨-ff69b4?style=for-the-badge)
 


### PR DESCRIPTION
## Summary
- clarify that `XSD_DATETYPE` is intentionally spelled and shouldn't be renamed

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683f9f139390832b8f1a6573909889c7