### PR TITLE
show predicate comments on click

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ const APP_ID: &str = "com.example.FileInformation";
 const TOOLTIP_MAX_CHARS: usize = 80;
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 const XSD_DATETYPE: &str = "http://www.w3.org/2001/XMLSchema#dateType";
+const RDFS_COMMENT: &str = "http://www.w3.org/2000/01/rdf-schema#comment";
 const FILEDATAOBJECT: &str = "http://tracker.api.gnome.org/ontology/v3/nfo#FileDataObject";
 
 fn main() {
@@ -295,6 +296,20 @@ fn populate_grid(app: &Application, window: &ApplicationWindow, grid: &Grid, uri
                         "Copy Native Predicate",
                     );
 
+                    let lbl_key_clone = lbl_key.clone();
+                    let pred_clone = pred.clone();
+                    let gesture = gtk::GestureClick::new();
+                    gesture.set_button(1);
+                    gesture.connect_pressed(move |_, _, _, _| {
+                        lbl_key_clone.set_tooltip_text(None);
+                        if let Some(comment) = fetch_comment(&pred_clone) {
+                            let tip = ellipsize(&comment, TOOLTIP_MAX_CHARS);
+                            lbl_key_clone.set_tooltip_text(Some(&tip));
+                            lbl_key_clone.trigger_tooltip_query();
+                        }
+                    });
+                    lbl_key.add_controller(gesture);
+
                     grid.attach(&lbl_key, 0, row, 1, 1);
                 }
 
@@ -466,6 +481,21 @@ where
     });
 
     widget.add_controller(gesture);
+}
+
+fn fetch_comment(predicate: &str) -> Option<String> {
+    let conn = SparqlConnection::bus_new("org.freedesktop.Tracker3.Miner.Files", None, None).ok()?;
+    let sparql = format!(
+        "SELECT ?c WHERE {{ <{pred}> <{comment}> ?c }} LIMIT 1",
+        pred = predicate,
+        comment = RDFS_COMMENT
+    );
+    let cursor = conn.query(&sparql, None::<&Cancellable>).ok()?;
+    if cursor.next(None::<&Cancellable>).unwrap_or(false) {
+        Some(cursor.string(0).unwrap_or_default().to_string())
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- show rdfs:comment when a predicate label is left-clicked
- add helper to query predicate comments

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684036be4ef0832b87bb6eb4003518df