### PR TITLE
Apply custom context menu to link labels

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn build_ui(app: &Application, uri: String) {
             padding: 0;
             border: none;
         }
-        button.link.no-padding * {
+        button.link.no-padding > * {
             padding: 0;
             margin: 0;
         }
@@ -593,7 +593,11 @@ where
         let rect = Rectangle::new(x as i32, y as i32, 1, 1);
         popover.set_pointing_to(Some(&rect));
 
-        popover.set_parent(&widget_clone);
+        if let Some(root) = widget_clone.root() {
+            popover.set_parent(&root);
+        } else {
+            popover.set_parent(&widget_clone);
+        }
         popover.popup();
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,11 @@ fn build_ui(app: &Application, uri: String) {
         }
         linkbutton.no-padding {
             padding: 0;
+            border: none;
+        }
+        linkbutton.no-padding * {
+            padding: 0;
+            margin: 0;
         }
     "#;
     provider.load_from_data(css);
@@ -419,6 +424,7 @@ fn populate_grid(
                         .uri(obj)
                         .label(obj)
                         .build();
+                    btn_link.set_has_frame(false);
                     btn_link.set_halign(gtk::Align::Start);
                     btn_link.set_margin_start(6);
                     btn_link.set_margin_top(4);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use gtk::WrapMode as GtkWrapMode;
 use gtk::pango;
 use gtk::{
     CssProvider, Grid, Label, TextView, Widget, Orientation, Button, Box as GtkBox,
-    LinkButton,
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -138,14 +137,6 @@ fn build_ui(app: &Application, uri: String) {
             border: 1px solid @separator_color;
             padding: 4px;
             margin-right: 6px;
-        }
-        button.link.no-padding {
-            padding: 0;
-            border: none;
-        }
-        button.link.no-padding > * {
-            padding: 0;
-            margin: 0;
         }
     "#;
     provider.load_from_data(css);
@@ -420,33 +411,32 @@ fn populate_grid(
                 let native_str = obj.clone();
 
                 let widget: gtk::Widget = if dtype.is_empty() {
-                    let btn_link = LinkButton::builder()
-                        .uri(obj)
-                        .label(obj)
-                        .build();
-                    btn_link.set_has_frame(false);
-                    btn_link.set_halign(gtk::Align::Start);
-                    btn_link.set_margin_start(6);
-                    btn_link.set_margin_top(4);
-                    btn_link.set_margin_bottom(4);
-                    btn_link.style_context().add_class("no-padding");
+                    let lbl_link = Label::new(None);
+                    lbl_link.set_markup(&format!("<a href=\"{0}\">{0}</a>", obj));
+                    lbl_link.set_halign(gtk::Align::Start);
+                    lbl_link.set_margin_start(6);
+                    lbl_link.set_margin_top(4);
+                    lbl_link.set_margin_bottom(4);
 
                     let app_clone = app.clone();
-                    btn_link.connect_activate_link(move |btn| {
-                        let uri = btn.uri();
+                    lbl_link.connect_activate_link(move |_lbl, uri| {
                         build_ui(&app_clone, uri.to_string());
                         Propagation::Stop
                     });
 
+                    lbl_link.set_wrap(true);
+                    lbl_link.set_wrap_mode(pango::WrapMode::WordChar);
+                    lbl_link.set_max_width_chars(80);
+
                     add_copy_menu(
-                        &btn_link,
+                        &lbl_link,
                         &displayed_str,
                         &native_str,
                         "Copy Displayed Value",
                         "Copy Native Value",
                     );
 
-                    btn_link.upcast()
+                    lbl_link.upcast()
                 } else {
                     if obj.contains('\n') {
                         let txt = TextView::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -590,14 +590,20 @@ where
 
         let popover = gtk::PopoverMenu::from_model(Some(&menu_model));
 
-        let rect = Rectangle::new(x as i32, y as i32, 1, 1);
-        popover.set_pointing_to(Some(&rect));
-
-        if let Some(root) = widget_clone.root() {
-            popover.set_parent(&root);
+        let (parent, rect) = if let Some(root) = widget_clone.root() {
+            if let Some((rx, ry)) = widget_clone
+                .translate_coordinates(&root, x, y)
+            {
+                (root.upcast::<Widget>(), Rectangle::new(rx as i32, ry as i32, 1, 1))
+            } else {
+                (root.upcast::<Widget>(), Rectangle::new(x as i32, y as i32, 1, 1))
+            }
         } else {
-            popover.set_parent(&widget_clone);
-        }
+            (widget_clone.clone(), Rectangle::new(x as i32, y as i32, 1, 1))
+        };
+
+        popover.set_parent(&parent);
+        popover.set_pointing_to(Some(&rect));
         popover.popup();
     });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,11 +139,11 @@ fn build_ui(app: &Application, uri: String) {
             padding: 4px;
             margin-right: 6px;
         }
-        linkbutton.no-padding {
+        button.link.no-padding {
             padding: 0;
             border: none;
         }
-        linkbutton.no-padding * {
+        button.link.no-padding * {
             padding: 0;
             margin: 0;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,6 +427,15 @@ fn populate_grid(
                     lbl_link.set_wrap(true);
                     lbl_link.set_wrap_mode(pango::WrapMode::WordChar);
                     lbl_link.set_max_width_chars(80);
+
+                    add_copy_menu(
+                        &lbl_link,
+                        &displayed_str,
+                        &native_str,
+                        "Copy Displayed Value",
+                        "Copy Native Value",
+                    );
+
                     lbl_link.upcast()
                 } else {
                     if obj.contains('\n') {

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,9 @@ fn build_ui(app: &Application, uri: String) {
             padding: 4px;
             margin-right: 6px;
         }
+        linkbutton.no-padding {
+            padding: 0;
+        }
     "#;
     provider.load_from_data(css);
     if let Some(display) = Display::default() {
@@ -420,6 +423,7 @@ fn populate_grid(
                     btn_link.set_margin_start(6);
                     btn_link.set_margin_top(4);
                     btn_link.set_margin_bottom(4);
+                    btn_link.style_context().add_class("no-padding");
 
                     let app_clone = app.clone();
                     btn_link.connect_activate_link(move |btn| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,6 +557,8 @@ where
 {
     let gesture = gtk::GestureClick::new();
     gesture.set_button(3);
+    gesture.set_exclusive(true);
+    gesture.set_propagation_phase(gtk::PropagationPhase::Capture);
 
     let disp_clone = displayed.to_string();
     let native_clone = native.to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use gtk::WrapMode as GtkWrapMode;
 use gtk::pango;
 use gtk::{
     CssProvider, Grid, Label, TextView, Widget, Orientation, Button, Box as GtkBox,
+    LinkButton,
 };
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -411,32 +412,31 @@ fn populate_grid(
                 let native_str = obj.clone();
 
                 let widget: gtk::Widget = if dtype.is_empty() {
-                    let lbl_link = Label::new(None);
-                    lbl_link.set_markup(&format!("<a href=\"{0}\">{0}</a>", obj));
-                    lbl_link.set_halign(gtk::Align::Start);
-                    lbl_link.set_margin_start(6);
-                    lbl_link.set_margin_top(4);
-                    lbl_link.set_margin_bottom(4);
+                    let btn_link = LinkButton::builder()
+                        .uri(obj)
+                        .label(obj)
+                        .build();
+                    btn_link.set_halign(gtk::Align::Start);
+                    btn_link.set_margin_start(6);
+                    btn_link.set_margin_top(4);
+                    btn_link.set_margin_bottom(4);
 
                     let app_clone = app.clone();
-                    lbl_link.connect_activate_link(move |_lbl, uri| {
+                    btn_link.connect_activate_link(move |btn| {
+                        let uri = btn.uri();
                         build_ui(&app_clone, uri.to_string());
                         Propagation::Stop
                     });
 
-                    lbl_link.set_wrap(true);
-                    lbl_link.set_wrap_mode(pango::WrapMode::WordChar);
-                    lbl_link.set_max_width_chars(80);
-
                     add_copy_menu(
-                        &lbl_link,
+                        &btn_link,
                         &displayed_str,
                         &native_str,
                         "Copy Displayed Value",
                         "Copy Native Value",
                     );
 
-                    lbl_link.upcast()
+                    btn_link.upcast()
                 } else {
                     if obj.contains('\n') {
                         let txt = TextView::new();


### PR DESCRIPTION
## Summary
- integrate `add_copy_menu` with link labels so right-click shows our custom menu

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684074fcd770832bb359f981725b2796