### PR TITLE
remove unsupported wait option

### DIFF
--- a/scripts/index_tmp_test.sh
+++ b/scripts/index_tmp_test.sh
@@ -43,5 +43,5 @@ tracker3 index --add /tmp/test --recursive
 tracker3 daemon -s
 
 # Wait for indexing to complete and display info
-tracker3 status --wait
+tracker3 status
 tracker3 info /tmp/test/yourfile.txt


### PR DESCRIPTION
## Summary
- remove `--wait` from `tracker3 status` in test script

## Testing
- `bash scripts/index_tmp_test.sh`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684140b2a1b4832bbcb07756f7ba1dfb