### PR TITLE
fix tracker3 invocation without dbus

### DIFF
--- a/scripts/index_tmp_test_min.sh
+++ b/scripts/index_tmp_test_min.sh
@@ -8,6 +8,12 @@ if [ ! -f "$TEST_DIR/yourfile.txt" ]; then
     echo "This is a test" > "$TEST_DIR/yourfile.txt"
 fi
 
+# Start a D-Bus session if needed
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    addr=$(dbus-daemon --session --fork --print-address)
+    export DBUS_SESSION_BUS_ADDRESS="$addr"
+fi
+
 # Add directory to index and start Tracker3 daemon
 tracker3 index --add --recursive "$TEST_DIR"
 tracker3 daemon -s


### PR DESCRIPTION
## Summary
- start a temporary D-Bus session in `index_tmp_test_min.sh`

## Testing
- `cargo test`
- `bash scripts/index_tmp_test_min.sh`

------
https://chatgpt.com/codex/tasks/task_e_68414b6aaa08832b98e02778019d5a8e