### PR TITLE
Limit wait for Tracker indexing

### DIFF
--- a/scripts/xvfb_screenshot.sh
+++ b/scripts/xvfb_screenshot.sh
@@ -52,7 +52,7 @@ tracker3 daemon -s >/dev/null
 tracker3 index --add "$TEST_DIR" >/dev/null
 
 # Wait for the test file to be indexed before launching the application
-echo "Waiting for Tracker to index $TEST_FILE (timeout 60s)..." >&2
+echo "Waiting up to 60 seconds for Tracker to index $TEST_FILE..." >&2
 for i in {1..60}; do
     if ! tracker3 info "$TEST_FILE" 2>&1 | grep -q "No metadata available"; then
         break
@@ -60,7 +60,7 @@ for i in {1..60}; do
     sleep 1
 done
 if tracker3 info "$TEST_FILE" 2>&1 | grep -q "No metadata available"; then
-    echo "Timed out waiting for Tracker to index $TEST_FILE" >&2
+    echo "Timed out waiting for Tracker to index $TEST_FILE." >&2
     exit 1
 fi
 

--- a/scripts/xvfb_screenshot.sh
+++ b/scripts/xvfb_screenshot.sh
@@ -52,10 +52,17 @@ tracker3 daemon -s >/dev/null
 tracker3 index --add "$TEST_DIR" >/dev/null
 
 # Wait for the test file to be indexed before launching the application
-echo "Waiting for Tracker to index $TEST_FILE..." >&2
-while tracker3 info "$TEST_FILE" 2>&1 | grep -q "No metadata available"; do
+echo "Waiting for Tracker to index $TEST_FILE (timeout 60s)..." >&2
+for i in {1..60}; do
+    if ! tracker3 info "$TEST_FILE" 2>&1 | grep -q "No metadata available"; then
+        break
+    fi
     sleep 1
 done
+if tracker3 info "$TEST_FILE" 2>&1 | grep -q "No metadata available"; then
+    echo "Timed out waiting for Tracker to index $TEST_FILE" >&2
+    exit 1
+fi
 
 # Query Tracker for metadata about the file to be shown in the application
 echo "Tracker metadata for $TEST_FILE:" >&2


### PR DESCRIPTION
## Summary
- stop `scripts/xvfb_screenshot.sh` from waiting indefinitely for tracker

## Testing
- `cargo test` *(fails: took too long to compile)*

------
https://chatgpt.com/codex/tasks/task_e_68430cd2bacc832bb8f8dad6b2679670