### PR TITLE
improve screenshot reliability

### DIFF
--- a/scripts/xvfb_screenshot.sh
+++ b/scripts/xvfb_screenshot.sh
@@ -85,6 +85,19 @@ if ! xdotool search --name "File Information" >/dev/null 2>&1; then
 fi
 
 window_id=$(xdotool search --name "File Information" | head -n 1)
+
+# Wait for the window to be fully drawn before taking a screenshot. The window
+# can exist before it has finished rendering, resulting in a blank capture. Use
+# xwininfo to check that the map state is "IsViewable" and give the GUI a bit of
+# extra time to paint.
+for i in {1..20}; do
+    if xwininfo -id "$window_id" | grep -q "IsViewable"; then
+        break
+    fi
+    sleep 0.5
+done
+sleep 1
+
 import -display "$XVFB_DISPLAY" -window "$window_id" "$SCREENSHOT"
 
 # Print geometry of the "File Information" window


### PR DESCRIPTION
## Summary
- wait for the window to be viewable before capturing the screenshot in `xvfb_screenshot.sh`

## Testing
- `cargo test`
- `bash scripts/xvfb_screenshot.sh`

------
https://chatgpt.com/codex/tasks/task_e_684377fa1560832ba56a86921b107933