### PR TITLE
Reference window by ID in screenshot script

### DIFF
--- a/scripts/xvfb_screenshot.sh
+++ b/scripts/xvfb_screenshot.sh
@@ -106,9 +106,9 @@ sleep 1
 echo "Saves screenshot of window $window_id on display $XVFB_DISPLAY to $SCREENSHOT..."
 import -display "$XVFB_DISPLAY" -window "$window_id" "$SCREENSHOT"
 
-# Print geometry of the "File Information" window
+# Print geometry using the captured window ID
 echo "Acquiring window geometry..."
-geom=$(xdotool search --name "File Information" getwindowgeometry --shell)
+geom=$(xdotool getwindowgeometry --shell "$window_id")
 eval "$geom"
 echo "Window geometry: X=$X Y=$Y WIDTH=$WIDTH HEIGHT=$HEIGHT" >&2
 
@@ -119,7 +119,7 @@ xdotool mousemove --sync "$close_x" "$close_y" click 1
 
 # Check if the window closed successfully
 sleep 1
-if xdotool search --name "File Information" >/dev/null 2>&1; then
+if xwininfo -id "$window_id" >/dev/null 2>&1; then
     echo "Window did not close." >&2
 else
     echo "Window closed successfully." >&2


### PR DESCRIPTION
## Summary
- use `xdotool getwindowgeometry` with the captured window ID
- check for window closure by ID instead of name
- clarify comment about obtaining geometry

## Testing
- `cargo test`
- attempted to run `bash scripts/xvfb_screenshot.sh`, but it failed to finish in this environment


------
https://chatgpt.com/codex/tasks/task_e_68438a755f2c832b9c29c56fad194e77