### PR TITLE
Set date in test setup

### DIFF
--- a/tests/bootstrap_environment.sh
+++ b/tests/bootstrap_environment.sh
@@ -15,4 +15,6 @@ xdg-mime default org.gnome.gedit.desktop text/plain
 # when handed to us.
 cargo clean
 
+date -s "2000-01-01 00:00:00"
+
 echo "ENVIRONMENT SETUP COMPLETE."


### PR DESCRIPTION
## Summary
- adjust `tests/bootstrap_environment.sh` to set the system date before finishing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6844317d4c68832b925990f8121df677