### PR TITLE
revert test date change

### DIFF
--- a/tests/bootstrap_environment.sh
+++ b/tests/bootstrap_environment.sh
@@ -15,6 +15,4 @@ xdg-mime default org.gnome.gedit.desktop text/plain
 # when handed to us.
 cargo clean
 
-date -s "2000-01-01 00:00:00"
-
 echo "ENVIRONMENT SETUP COMPLETE."


### PR DESCRIPTION
## Summary
- revert the date command from `tests/bootstrap_environment.sh`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68444512fbc8832ba27cffeed4dd0c88