### PR TITLE
Install faketime for tests

### DIFF
--- a/tests/bootstrap_environment.sh
+++ b/tests/bootstrap_environment.sh
@@ -8,7 +8,7 @@ apt-get install -y libglib2.0-dev libcairo2-dev libpango1.0-dev libgdk-pixbuf2.0
 
 # Install testing dependencies.
 apt-get install -y xvfb dbus-x11 xdotool imagemagick
-apt-get install -y tracker gedit xdg-utils
+apt-get install -y tracker faketime gedit xdg-utils
 xdg-mime default org.gnome.gedit.desktop text/plain
 
 # Clean out any existing build artifacts in case the space was not pristine

--- a/tests/graphical/run_tests.sh
+++ b/tests/graphical/run_tests.sh
@@ -49,6 +49,8 @@ mkdir -p "$TEST_DIR"
 if [ ! -f "$TEST_FILE" ]; then
     echo "The quick brown fox jumps over the lazy dog." > "$TEST_FILE"
 fi
+# Ensure the file timestamp is constant for reproducible tests
+touch -d '2000-01-01 00:00:00' "$TEST_FILE"
 
 echo "Launching Xvfb on display $XVFB_DISPLAY and piping output to $XVFB_LOG..."
 Xvfb "$XVFB_DISPLAY" -screen 0 1024x768x24 >"$XVFB_LOG" 2>&1 &
@@ -67,7 +69,7 @@ fi
 
 echo "Initiating Tracker indexing of $TEST_DIR..."
 # Let Tracker index the test directory.
-tracker3 daemon -s >/dev/null
+faketime '2000-01-01 00:00:00' tracker3 daemon -s >/dev/null
 tracker3 index --add "$TEST_DIR" >/dev/null
 
 # Wait for the test file to be indexed before launching the application


### PR DESCRIPTION
## Summary
- install faketime before gedit
- run tracker3 daemon under faketime
- give the test file a fixed timestamp

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684440f5d2a4832b99031307e6c6d84b