### PR TITLE
Add deb packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,19 @@ url = "2"
 
 tracker     = { package = "tracker-rs", version = "0.6" }
 
+[package.metadata.deb]
+maintainer = "Example Maintainer <maintainer@example.com>"
+copyright = "2024, Example Maintainer"
+section = "utils"
+priority = "optional"
+extended-description = "A GTK application that shows Tracker metadata for files"
+depends = "$auto"
+assets = [
+    ["target/release/file-information", "usr/bin/", "755"],
+    ["resources/file-information.desktop", "usr/share/applications/", "644"],
+]
+maintainer-scripts = "debian"
+
 [build-dependencies]
 system-deps = "7"
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# File Information
+
+This application displays metadata about files using GNOME Tracker.
+
+## Building
+
+```bash
+cargo build --release
+```
+
+## Packaging
+
+A Debian package can be created with [`cargo-deb`](https://github.com/mmstick/cargo-deb).
+After installing `cargo-deb`, run:
+
+```bash
+cargo deb --no-build
+```
+
+The resulting `.deb` installs a desktop entry so the application appears
+in GNOME's **Open With** dialog for folders and any file type. The
+desktop database is refreshed on install and removal.

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+update-desktop-database /usr/share/applications >/dev/null 2>&1 || true

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+update-desktop-database /usr/share/applications >/dev/null 2>&1 || true

--- a/resources/file-information.desktop
+++ b/resources/file-information.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=File Information
+Comment=Display Tracker metadata for files
+Exec=file-information %U
+Terminal=false
+Icon=dialog-information
+Categories=Utility;
+MimeType=inode/directory;application/octet-stream;text/plain;image/png;image/jpeg;audio/mpeg;video/mp4;


### PR DESCRIPTION
## Summary
- package `file-information` as a .deb using `cargo-deb`
- install a desktop entry for GNOME integration
- refresh the desktop database on install and removal
- document how to build the package

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68459144a3cc832ba1e5a445c41fec7b